### PR TITLE
Update version of slurm-wlm to 20.11.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # FROM debian:latest
-FROM ubuntu:latest
+FROM ubuntu:impish
 STOPSIGNAL SIGRTMIN+3
 
 ENV TZ=Europe/Berlin
@@ -9,6 +9,7 @@ RUN apt update
 RUN apt install -y systemd ssh sudo slurm-wlm slurm-wlm-basic-plugins munge libmunge2 make perl psmisc build-essential wget python3 python3-pip python3-dev libopenmpi3 libopenmpi-dev openmpi-bin openmpi-common bash-completion vim emacs nano
 
 # TODO: Install newer version of slurm, https://slurm.schedmd.com/download.html, and installation guide, https://slurm.schedmd.com/quickstart_admin.html
+# Currently the version of slurm-wlm is obtained from Ubuntu 21.10 under version (20.11.7+really20.11.4-2)
 
 RUN mkdir /var/spool/slurmd
 RUN chown -R slurm:slurm /var/spool/slurm*


### PR DESCRIPTION
This version of slurm-wlm is introduced by an upgrade of Docker image to Ubuntu 21.10